### PR TITLE
Reescrevendo em Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Outras linguagens?
 ----
 Versões da biblioteca *tempconv* para outras linguagens:
 
-> *Todo*
+> * [Rust](./outras_linguagens/Rust/README.md)
 
 Veja como contribuir escrevendo em outra linguagem [aqui](./outras_linguagens/outras_linguagens.md)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Versões da biblioteca *tempconv* para outras linguagens:
 
 > *Todo*
 
+Veja como contribuir escrevendo em outra linguagem [aqui](./outras_linguagens/outras_linguagens.md)
 
 Licença
 -----

--- a/outras_linguagens/Rust/.gitignore
+++ b/outras_linguagens/Rust/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/outras_linguagens/Rust/Cargo.toml
+++ b/outras_linguagens/Rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/outras_linguagens/Rust/README.md
+++ b/outras_linguagens/Rust/README.md
@@ -1,0 +1,1 @@
+Rust lang

--- a/outras_linguagens/Rust/README.md
+++ b/outras_linguagens/Rust/README.md
@@ -1,1 +1,11 @@
-Rust lang
+Implementação do tempconv em Rust:
+===
+
+### Como instalar a linguagem:
+1. Siga as instruções para instalação do [_rustup_](https://rustup.rs/) que é o instalador do ecossistema e todo ferramental Rust. Uma vez instalado o rustup, o gerenciador de projetos `cargo` estará instalado e será necessário para executar e o projeto.
+
+2. Dentro da pasta `Rust` faça o comando:
+    ```
+    $ cargo run 
+    ``` 
+    para compilar e executrar o programa.

--- a/outras_linguagens/Rust/src/main.rs
+++ b/outras_linguagens/Rust/src/main.rs
@@ -1,0 +1,7 @@
+pub mod tempconv;
+
+use tempconv::Temperatures;
+fn main() {
+    println!("Que frio! {:?}", Temperatures::Celsius(0.0).absolute_zero());
+    println!("Fervendo! {:?}", Temperatures::Celsius(0.0).to_fahrenheit().boiling());
+}

--- a/outras_linguagens/Rust/src/tempconv.rs
+++ b/outras_linguagens/Rust/src/tempconv.rs
@@ -1,0 +1,56 @@
+#[derive(Debug)]
+pub enum Temperatures {
+    Celsius(f64),
+    Fahrenheit(f64),
+    Kelvin(f64),
+}
+
+impl Temperatures {
+    pub fn boiling(&self) -> Self {
+        match self {
+            Self::Celsius(_) => Self::Celsius(100.00),
+            Self::Fahrenheit(_) => Self::Fahrenheit(212.00),
+            Self::Kelvin(_) => Self::Kelvin(373.15),
+        }
+    }
+
+    pub fn absolute_zero(&self) -> Self {
+        match self {
+            Self::Celsius(_) => Self::Celsius(-273.15),
+            Self::Fahrenheit(_) => Self::Fahrenheit(-459.67),
+            Self::Kelvin(_) => Self::Kelvin(0.0),
+        }
+    }
+
+    pub fn freezing(&self) -> Self {
+        match self {
+            Self::Celsius(_) => Self::Celsius(0.0),
+            Self::Fahrenheit(_) => Self::Fahrenheit(32.0),
+            Self::Kelvin(_) => Self::Kelvin(273.15),
+        }
+    }
+
+    pub fn to_celsius(&self) -> Self {
+        match self {
+            Self::Celsius(temperature) => Self::Celsius(*temperature),
+            Self::Fahrenheit(temperature) => Self::Celsius(5.0 / 9.0 * temperature - 32.0),
+            Self::Kelvin(temperature) => Self::Celsius(temperature - 273.15),
+        }
+    }
+
+    pub fn to_fahrenheit(&self) -> Self {
+        match self {
+            Self::Celsius(temperature) => Self::Fahrenheit(9.0 / 5.0 * temperature + 32.0),
+            Self::Fahrenheit(temperature) => Self::Fahrenheit(*temperature),
+            Self::Kelvin(temperature) => Self::Fahrenheit(9.0 / 5.0 * temperature - 459.67),
+        }
+    }
+
+    pub fn to_kelvin(&self) -> Self {
+        match self {
+            Self::Celsius(temperature) => Self::Kelvin(temperature + 273.15),
+            Self::Fahrenheit(temperature) => Self::Kelvin(5.0 / 9.0 * temperature + 459.67),
+            Self::Kelvin(temperature) => Self::Kelvin(*temperature),
+        }
+    }
+}

--- a/outras_linguagens/outras_linguagens.md
+++ b/outras_linguagens/outras_linguagens.md
@@ -1,0 +1,29 @@
+Reimplementando *tempconv* em outra linguagem
+=====
+
+Os passos a seguir irão te orientar como colocar sua reimplementação no projeto:
+----
+
+***1.** Entre na pasta `outras_linguagens/` .*
+
+***2.** Crie uma pasta com nome da linguagem que deseja reescrever o projeto.*
+
+***3.** dentro da pasta criada deve ter seu próprio README com instruções de configuração para executar o projeto.*
+
+***4.** O `README.md` do projeto deve conter o caminho para o arquivo `como_executar.md` para já instruir a pessoa como executar sua reimplementação.*
+
+> Este é um exemplo de como ficaria a estrutura do projeto com implementação em C++:
+```
+.
+├── go.mod
+├── main.go
+├── outras_linguagens
+│   ├── c++
+│   │   ├── como_executar.md
+│   │   └── main.cpp
+│   └── outras_linguagens.md
+├── README.md
+└── tempconv
+    └── tempconv.go
+```
+> ***Divirta-se***

--- a/outras_linguagens/outras_linguagens.md
+++ b/outras_linguagens/outras_linguagens.md
@@ -10,7 +10,7 @@ Os passos a seguir irão te orientar como colocar sua reimplementação no proje
 
 ***3.** dentro da pasta criada deve ter seu próprio README com instruções de configuração para executar o projeto.*
 
-***4.** O `README.md` do projeto deve conter o caminho para o arquivo `como_executar.md` para já instruir a pessoa como executar sua reimplementação.*
+***4.** O `README.md` raiz do projeto deve conter o caminho para o arquivo `README.md` dentro da pasta linguagem desejada, para já instruir a pessoa como executar sua reimplementação.*
 
 > Este é um exemplo de como ficaria a estrutura do projeto com implementação em C++:
 ```
@@ -19,7 +19,7 @@ Os passos a seguir irão te orientar como colocar sua reimplementação no proje
 ├── main.go
 ├── outras_linguagens
 │   ├── c++
-│   │   ├── como_executar.md
+│   │   ├── README.md
 │   │   └── main.cpp
 │   └── outras_linguagens.md
 ├── README.md


### PR DESCRIPTION
Criação e construção do projeto de `tempconv` na linguagem _Rust_, com adição de implementação para Kelvin e outras conversões. Não possui atualmente documentação para funções e dados, e não possui formatação própria que seria necessário.

Por acidente o PR inclui as alterações de inclusão de orientações de documentar o código na implementação de outras linguagens.

referênte a issue Nº #4 