### PR TITLE
Considerar escala Kelvin #5

### DIFF
--- a/tempconv/tempconv.go
+++ b/tempconv/tempconv.go
@@ -4,6 +4,7 @@ import "fmt"
 
 type Celsius float64
 type Fahrenheit float64
+type Kelvin float64
 
 const (
 	// AbsoluteZeroC representa a temperatura zero absoluto em Celsius
@@ -22,8 +23,23 @@ func (c Celsius) String() string { return fmt.Sprintf("%g°C", c) }
 // String imprime uma temperatura 'n' em Fahrenheit no formato n°F
 func (f Fahrenheit) String() string { return fmt.Sprintf("%g°F", f) }
 
+// String imprime uma temperatura 'n' em Kelvin no formato nK
+func (k Kelvin) String() string { return fmt.Sprintf("%gK", k) }
+
 // CToF converte uma temperatura em Celsius para Fahrenheit
 func CToF(c Celsius) Fahrenheit { return Fahrenheit(c*9/5 + 32) }
 
 // FToC converte uma temperatura em Fahrenheit para Celsius
 func FToC(f Fahrenheit) Celsius { return Celsius((f - 32) * 5 / 9) }
+
+// CToK converte uma temperatura em Celsius para Kelvin
+func CToK(c Celsius) Kelvin { return Kelvin( c + 273.15 ) }
+
+// KToC converte uma temperatura em Kelvin para Celsius
+func CToK(k Kelvin) Celsius { return Celsius( k - 273.15 ) }
+
+// FtoK converte uma temperatura em Fahrenheit para Kelvin
+func FtoK(f Fahrenheit) Kelvin { return Kelvin( (f - 32) * 5/9 + 273.15 )}
+
+// KtoF converte uma temperatura em Kelvin para Fahrenheit
+func KtoF(k Kelvin) Fahrenheit { return Fahrenheit( (k - 273.15) * 9/5 + 32 )}


### PR DESCRIPTION
Criação de novas funções e tipos públicos, capazes de realizar conversões de temperaturas para a escala Kelvin, como de Fahrenheit e Celsius para Kelvin, como de Kelvin para as demais.